### PR TITLE
Actual translation from English to Spanish

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,5 @@
 es:
   cookies_eu:
-    cookies_text: "Usamos cookies para ofrecerte un mejor servicio, en ningún caso usamos tus datos para nuestro beneficio personal o para vendérselos a terceros. Si continúas navegando aceptas nuestro uso de las Cookies."
+    cookies_text: "Las cookies nos ayudan a ofrecer nuestros servicios. Al utilizar nuestros servicios, aceptas el uso de cookies."
     learn_more: "Más información"
     ok: "OK"


### PR DESCRIPTION
I realized that the English text didn't say the same than the Spanish one, so I translated it manually.

Bonus: after translating it to Spanish, it results in a shorter and clearer text than the current translation, so it's twice better :wink:.