### PR TITLE
Update cookies_eu.js

### DIFF
--- a/app/assets/javascripts/cookies_eu.js
+++ b/app/assets/javascripts/cookies_eu.js
@@ -1,4 +1,3 @@
-//= require jquery
 //= require jquery.cookie
 
 $(document).ready( function(){


### PR DESCRIPTION
Remove //= require jquery in head of cookies_eu.js to prevent the overload the use of jquery2 in the main app's application.js by jquery 1. Cookies Eu works well with version 2 of jquery.