### PR TITLE
Update cookies_eu.js

### DIFF
--- a/app/assets/javascripts/cookies_eu.js
+++ b/app/assets/javascripts/cookies_eu.js
@@ -3,7 +3,7 @@
 $(document).ready( function(){
   $('.cookies-eu-ok').click(function(e){
     e.preventDefault();
-    $.cookie('cookie_eu_consented', 'true', { path: '/', expires: 365 });
+    $.cookie('cookie_eu_consented', true, { path: '/', expires: 365 });
     $('.cookies-eu').remove();
   });
 });


### PR DESCRIPTION
Do not quote the "true" value when the "cookie_eu_consented" cookie is set.

The quoting breaks the test for the cookie value in the cookie consent partial template. The result is that the partial always renders the banner, even after the user has consented.