### PR TITLE
Remove jQuery and replace jquery-cookie-rails with js-cookie

### DIFF
--- a/app/assets/javascripts/cookies_eu.js
+++ b/app/assets/javascripts/cookies_eu.js
@@ -1,9 +1,33 @@
-//= require jquery.cookie
+//= require js.cookie
+'use strict';
 
-$(document).ready( function(){
-  $('.cookies-eu-ok').click(function(e){
-    e.preventDefault();
-    $.cookie('cookie_eu_consented', true, { path: '/', expires: 365 });
-    $('.cookies-eu').remove();
-  });
+document.addEventListener('DOMContentLoaded', function() {
+
+  var cookiesEu = {
+    init: function() {
+      var cookiesEuOKButton = document.querySelector('.js-cookies-eu-ok');
+
+      if (cookiesEuOKButton) {
+        this.addListener(cookiesEuOKButton);
+      }
+    },
+
+    addListener: function(target) {
+      // Support for IE < 9
+      if (target.attachEvent) {
+        target.attachEvent('onclick', this.setCookie);
+      } else {
+        target.addEventListener('click', this.setCookie, false);
+      }
+    },
+
+    setCookie: function() {
+      Cookies.set('cookie_eu_consented', true, { path: '/', expires: 365 });
+
+      document.querySelector('.js-cookies-eu').remove();
+    }
+  }
+
+  cookiesEu.init();
+
 });

--- a/app/views/cookies_eu/_consent_banner.html.erb
+++ b/app/views/cookies_eu/_consent_banner.html.erb
@@ -1,8 +1,8 @@
 <% if cookies['cookie_eu_consented'] != 'true' %>
-  <div class="cookies-eu">
+  <div class="cookies-eu js-cookies-eu">
     <span class="cookies-eu-content-holder"><%= t('cookies_eu.cookies_text') %></span>
     <span class="cookies-eu-button-holder">
-    <button class="cookies-eu-ok"> <%= t('cookies_eu.ok') %> </button>
+    <button class="cookies-eu-ok js-cookies-eu-ok"> <%= t('cookies_eu.ok') %> </button>
     <% if defined?(link).present? %>
       <a href="<%= link %>" class="cookies-eu-link" target="<%= defined?(target).present? ? target : '' %>"> <%= t('cookies_eu.learn_more') %> </a>
     <% end %>

--- a/cookies_eu.gemspec
+++ b/cookies_eu.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jquery-rails"
-  spec.add_dependency "jquery-cookie-rails"
+  spec.add_dependency "js_cookie_rails"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end

--- a/lib/cookies_eu.rb
+++ b/lib/cookies_eu.rb
@@ -1,7 +1,6 @@
 require "cookies_eu/version"
 require "cookies_eu/engine"
-require 'jquery-rails'
-require 'jquery-cookie-rails'
+require "js_cookie_rails"
 
 module CookiesEu
 end

--- a/lib/cookies_eu/version.rb
+++ b/lib/cookies_eu/version.rb
@@ -1,3 +1,3 @@
 module CookiesEu
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Removed jQuery (also needed to add support for IE lower than 9) and replaced jquery-cookie-rails with js-cookie because he has support for all browsers and is well maintained