### PR TITLE
Improve slovak locale

### DIFF
--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,5 +1,5 @@
 sk:
   cookies_eu:
-    cookies_text: "Pre zlepšenie užívateľského komfortu užívateľov našich internetových stránok a na zabezpečenie ďalších úloh požívame cookies. Používaním s týmto súhlasíte."
-    learn_more: "Dozvedieť sa viac"
+    cookies_text: "Cookies nám pomáhajú poskytovať Vám naše služby. Využívaním týchto služieb súhlasíte s ich použitím."
+    learn_more: "Oboznámiť sa podrobnejšie"
     ok: "OK"


### PR DESCRIPTION
Too complicated previous translation not fully grammatically and semantically correct.