### PR TITLE
Improve czech locale

### DIFF
--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,5 +1,5 @@
 cs:
   cookies_eu:
-    cookies_text: "Pro zlepšení uživatelského komfortu uživatelů našich internetových stránek a pro zajištění dalších úkolů požíváme cookies. Používáním s tímto souhlasíte."
+    cookies_text: "Cookies nám pomáhají poskytovat Vám naše služby. Využíváním těchto služeb souhlasíte s jejich použitím."
     learn_more: "Dozvědět se více"
     ok: "OK"


### PR DESCRIPTION
Too complicated previous translation not fully grammatically and semantically correct.