### PR TITLE
Integrate with application.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Or manually add in application.js:
 And in application.css:
 
     *= require cookies_eu
+    
+Or, if you have application.scss:
+
+    @import "cookies_eu";
+
+Remember to restart your server!
 
 ## Usage
 


### PR DESCRIPTION
Just a small extension to explain how to add the `scss` file when you use `application.scss` rather than `application.css`