### PR TITLE
Fixed exception where cookies[] was nil in consent banner

### DIFF
--- a/app/views/cookies_eu/_consent_banner.html.erb
+++ b/app/views/cookies_eu/_consent_banner.html.erb
@@ -1,4 +1,4 @@
-<% if cookies['cookie_eu_consented'] != 'true' %>
+<% if cookies && cookies['cookie_eu_consented'] != 'true' %>
   <div class="cookies-eu js-cookies-eu">
     <span class="cookies-eu-content-holder"><%= t('cookies_eu.cookies_text') %></span>
     <span class="cookies-eu-button-holder">


### PR DESCRIPTION
A simple check that `cookies` is not nil before checking `cookies['cookie_eu_consented']`.