### PR TITLE
More easily support webpacker

### DIFF
--- a/app/assets/javascripts/cookies_eu.js
+++ b/app/assets/javascripts/cookies_eu.js
@@ -1,4 +1,4 @@
-//= require js.cookie
+const Cookies = require('./js.cookie');
 'use strict';
 
 var windowIsTurbolinked = 'Turbolinks' in window;

--- a/app/assets/javascripts/js.cookie.js
+++ b/app/assets/javascripts/js.cookie.js
@@ -1,0 +1,163 @@
+/*!
+ * JavaScript Cookie v2.2.1
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+    var registeredInModuleLoader;
+    if (typeof define === 'function' && define.amd) {
+        define(factory);
+        registeredInModuleLoader = true;
+    }
+    if (typeof exports === 'object') {
+        module.exports = factory();
+        registeredInModuleLoader = true;
+    }
+    if (!registeredInModuleLoader) {
+        var OldCookies = window.Cookies;
+        var api = window.Cookies = factory();
+        api.noConflict = function () {
+            window.Cookies = OldCookies;
+            return api;
+        };
+    }
+}(function () {
+    function extend () {
+        var i = 0;
+        var result = {};
+        for (; i < arguments.length; i++) {
+            var attributes = arguments[ i ];
+            for (var key in attributes) {
+                result[key] = attributes[key];
+            }
+        }
+        return result;
+    }
+
+    function decode (s) {
+        return s.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent);
+    }
+
+    function init (converter) {
+        function api() {}
+
+        function set (key, value, attributes) {
+            if (typeof document === 'undefined') {
+                return;
+            }
+
+            attributes = extend({
+                path: '/'
+            }, api.defaults, attributes);
+
+            if (typeof attributes.expires === 'number') {
+                attributes.expires = new Date(new Date() * 1 + attributes.expires * 864e+5);
+            }
+
+            // We're using "expires" because "max-age" is not supported by IE
+            attributes.expires = attributes.expires ? attributes.expires.toUTCString() : '';
+
+            try {
+                var result = JSON.stringify(value);
+                if (/^[\{\[]/.test(result)) {
+                    value = result;
+                }
+            } catch (e) {}
+
+            value = converter.write ?
+                converter.write(value, key) :
+                encodeURIComponent(String(value))
+                    .replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+
+            key = encodeURIComponent(String(key))
+                .replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent)
+                .replace(/[\(\)]/g, escape);
+
+            var stringifiedAttributes = '';
+            for (var attributeName in attributes) {
+                if (!attributes[attributeName]) {
+                    continue;
+                }
+                stringifiedAttributes += '; ' + attributeName;
+                if (attributes[attributeName] === true) {
+                    continue;
+                }
+
+                // Considers RFC 6265 section 5.2:
+                // ...
+                // 3.  If the remaining unparsed-attributes contains a %x3B (";")
+                //     character:
+                // Consume the characters of the unparsed-attributes up to,
+                // not including, the first %x3B (";") character.
+                // ...
+                stringifiedAttributes += '=' + attributes[attributeName].split(';')[0];
+            }
+
+            return (document.cookie = key + '=' + value + stringifiedAttributes);
+        }
+
+        function get (key, json) {
+            if (typeof document === 'undefined') {
+                return;
+            }
+
+            var jar = {};
+            // To prevent the for loop in the first place assign an empty array
+            // in case there are no cookies at all.
+            var cookies = document.cookie ? document.cookie.split('; ') : [];
+            var i = 0;
+
+            for (; i < cookies.length; i++) {
+                var parts = cookies[i].split('=');
+                var cookie = parts.slice(1).join('=');
+
+                if (!json && cookie.charAt(0) === '"') {
+                    cookie = cookie.slice(1, -1);
+                }
+
+                try {
+                    var name = decode(parts[0]);
+                    cookie = (converter.read || converter)(cookie, name) ||
+                        decode(cookie);
+
+                    if (json) {
+                        try {
+                            cookie = JSON.parse(cookie);
+                        } catch (e) {}
+                    }
+
+                    jar[name] = cookie;
+
+                    if (key === name) {
+                        break;
+                    }
+                } catch (e) {}
+            }
+
+            return key ? jar[key] : jar;
+        }
+
+        api.set = set;
+        api.get = function (key) {
+            return get(key, false /* read as raw */);
+        };
+        api.getJSON = function (key) {
+            return get(key, true /* read as json */);
+        };
+        api.remove = function (key, attributes) {
+            set(key, '', extend(attributes, {
+                expires: -1
+            }));
+        };
+
+        api.defaults = {};
+
+        api.withConverter = init;
+
+        return api;
+    }
+
+    return init(function () {});
+}));

--- a/cookies_eu.gemspec
+++ b/cookies_eu.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "js_cookie_rails", "~> 2.2.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end

--- a/lib/cookies_eu.rb
+++ b/lib/cookies_eu.rb
@@ -1,6 +1,5 @@
 require "cookies_eu/version"
 require "cookies_eu/engine"
-require "js_cookie_rails"
 
 module CookiesEu
 end


### PR DESCRIPTION
Drop js_cookie_rails gem from dependency and add js.cookie package directly.
If we do this we can use instructions from #75 to use it with webpacker