### PR TITLE
Stops blank target being set

### DIFF
--- a/app/views/cookies_eu/_consent_banner.html.erb
+++ b/app/views/cookies_eu/_consent_banner.html.erb
@@ -5,7 +5,7 @@
       <span class="cookies-eu-button-holder">
       <button class="cookies-eu-ok js-cookies-eu-ok"> <%= t('cookies_eu.ok') %> </button>
       <% if defined?(link).present? %>
-        <a href="<%= link %>" class="cookies-eu-link" target="<%= defined?(target).present? ? target : '' %>"> <%= t('cookies_eu.learn_more') %> </a>
+        <a href="<%= link %>" class="cookies-eu-link" <% if defined?(target).present? %>target="<%= target %>"<% end %> <%= t('cookies_eu.learn_more') %> </a>
       <% end %>
       </span>
     </div>


### PR DESCRIPTION
With no target being defined (`target=""`) we end up with invalid HTML, this ensures this doesn't happen.