### PR TITLE
Improve Romanian translation texts

### DIFF
--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,5 +1,5 @@
 ro:
   cookies_eu:
-    cookies_text: "Cookies ne ajuta la livrarea serviciului. Folosind serviciul nostru, consemnati la utilizarea cookies-urilor."
-    learn_more: "Mai multe"
+    cookies_text: "Cookie-urile ne ajută la livrarea serviciului. Folosind serviciul nostru, consemnați la utilizarea cookie-urilor."
+    learn_more: "Mai multe informații"
     ok: "OK"


### PR DESCRIPTION
I've made some minor improvements to the Romanian translation:

- Replaced the spelling `Cookies` with the spelling `Cookie-uri`, which is accepted/preferred in Romanian and used in, for example, the [Google Chrome docs on deleting cookies](https://support.google.com/chrome/answer/95647?hl=ro&co=GENIE.Platform%3DDesktop)
- Added diacritics
- I've updated the `learn_more` text to say "More information" instead of literally just "More"